### PR TITLE
Add workflow attributes on all spans

### DIFF
--- a/overmind/langchain/callbacks.py
+++ b/overmind/langchain/callbacks.py
@@ -82,13 +82,9 @@ class OvermindObservabilityCallback(BaseCallbackHandler):
 
             if self.graph:
                 metadata["graph"] = self.parse_graph(self.graph)
-                graph_hash = hashlib.sha256(
+                self.graph_hash = hashlib.sha256(
                     json.dumps(metadata["graph"], sort_keys=True).encode('utf-8')
                 ).hexdigest()
-
-                self.run_spans[run_id].set_attribute("workflow_name", self.name)
-                self.run_spans[run_id].set_attribute("workflow_hash", graph_hash)
-                self.run_spans[run_id].set_attribute("workflow_tags", serialize(self.tags) if isinstance(self.tags, dict) else '{}')
 
         else:
             parent_context = trace.set_span_in_context(
@@ -98,6 +94,11 @@ class OvermindObservabilityCallback(BaseCallbackHandler):
                 name=name,
                 context=parent_context,
             )
+
+        if self.graph:
+            self.run_spans[run_id].set_attribute("workflow_name", self.name)
+            self.run_spans[run_id].set_attribute("workflow_hash", self.graph_hash)
+            self.run_spans[run_id].set_attribute("workflow_tags", serialize(self.tags) if isinstance(self.tags, dict) else '{}')
 
         self.run_spans[run_id].set_attribute("metadata", serialize(metadata))
         self.run_spans[run_id].set_attribute("inputs", serialize(inputs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "overmind"
-version = "0.1.11"
+version = "0.1.12"
 description = "Python client for Overmind API"
 authors = ["Overmind Ltd"]
 readme = "README.md"


### PR DESCRIPTION
Send workflow attributes (name, hash, tags) on all spans for easier retrieval. Since the size of this repeated data isn't large the impact on payload size will be minimal.