### PR TITLE
Add tracing context to proxy response model

### DIFF
--- a/overmind/models.py
+++ b/overmind/models.py
@@ -154,6 +154,7 @@ class ProxyRunResponse(ReadableBaseModel):
     output_layer_results: Dict[str, Any]
     processed_output: Any
     processed_input: Any
+    span_context: Dict[str, Any]
 
     def summary(self) -> None:
         summarize_proxy_run(self)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "overmind"
-version = "0.1.12"
+version = "0.1.13"
 description = "Python client for Overmind API"
 authors = ["Overmind Ltd"]
 readme = "README.md"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -85,6 +85,7 @@ class TestClientIntegration:
                     "output_layer_results": {},
                     "processed_input": "test input",
                     "processed_output": "test output",
+                    "span_context": {},
                 },
                 content=b'{"llm_client_response": {"choices": [{"message": {"content": "Hello"}}]}}',
             ),

--- a/tests/test_client_main.py
+++ b/tests/test_client_main.py
@@ -62,6 +62,7 @@ class TestOvermindClient:
             "output_layer_results": {},
             "processed_input": "test input",
             "processed_output": "test output",
+            "span_context": {},
         }
         mock_response.content = (
             b'{"llm_client_response": {"choices": [{"message": {"content": "Hello"}}]}}'
@@ -133,6 +134,7 @@ class TestOvermindClient:
             "output_layer_results": {},
             "processed_input": "test input",
             "processed_output": "test output",
+            "span_context": {},
         }
         mock_response.content = (
             b'{"llm_client_response": {"choices": [{"message": {"content": "Hello"}}]}}'
@@ -162,6 +164,7 @@ class TestOvermindClient:
             "output_layer_results": {},
             "processed_input": "test input",
             "processed_output": "test output",
+            "span_context": {},
         }
         mock_response.content = (
             b'{"llm_client_response": {"choices": [{"message": {"content": "Hello"}}]}}'


### PR DESCRIPTION
Adding trace id and parent span it to proxy response to allow linking with client initiated traces.